### PR TITLE
Mouseend listener never gets unregistered

### DIFF
--- a/js/jquery.event.move.js
+++ b/js/jquery.event.move.js
@@ -222,7 +222,7 @@
 
 	function removeMouse() {
 		remove(document, mouseevents.move, mousemove);
-		remove(document, mouseevents.cancel, removeMouse);
+		remove(document, mouseevents.cancel, mouseend);
 	}
 
 	function touchstart(e) {


### PR DESCRIPTION
This appears to be a typo in the library. If many mouse down/up events are sent to the page, eventually the mouseend function gets called bajillions of times because it is registered on each mousedown but never unregistered. This causes, for example, the issue at https://bugzilla.mozilla.org/show_bug.cgi?id=833540 in Firefox for Android.
